### PR TITLE
MYR-564: Button send tip still active on claimed socmed account

### DIFF
--- a/src/components/post/post-action.hook.ts
+++ b/src/components/post/post-action.hook.ts
@@ -24,6 +24,16 @@ export const usePostActionHook = (post: Post) => {
 
     if (user) {
       setTippingEnabled(user.id !== post.platformUser?.platform_account_id);
+
+      // disable tipping for imported posts that he/she owns
+      if (user.userCredentials) {
+        user.userCredentials.forEach(credential => {
+          if (credential.people.platform_account_id === post.platformUser?.platform_account_id) {
+            console.count('found post!');
+            setTippingEnabled(false);
+          }
+        });
+      }
     } else {
       setTippingEnabled(false);
     }


### PR DESCRIPTION
- Users who just claimed their social accounts will not be able to send tip to imported posts owned by them