### PR TITLE
When search people on ExperienceEditor, typed keywords should not disappear

### DIFF
--- a/src/components-v2/ExperienceEditor/ExperienceEditor.tsx
+++ b/src/components-v2/ExperienceEditor/ExperienceEditor.tsx
@@ -27,6 +27,7 @@ import {ListItemComponent} from '../atoms/ListItem';
 import {useStyles} from './Experience.styles';
 
 import {debounce} from 'lodash';
+import {SocialsEnum} from 'src/interfaces/social';
 
 type ExperienceEditorProps = {
   type?: string;
@@ -44,7 +45,18 @@ export const ExperienceEditor: React.FC<ExperienceEditorProps> = props => {
     props;
   const styles = useStyles();
 
-  const [newExperience, setNewExperience] = useState<Partial<Experience>>();
+  const [newExperience, setNewExperience] = useState<Partial<Experience>>({
+    people: [
+      {
+        id: '',
+        name: '',
+        originUserId: '',
+        platform: SocialsEnum.TWITTER,
+        profilePictureURL: '',
+        username: '',
+      },
+    ],
+  });
   const [newTags, setTags] = useState<string[]>([]);
   const [image, setImage] = useState<string>();
   const [disable, setDisable] = useState<boolean>(true);
@@ -248,7 +260,7 @@ export const ExperienceEditor: React.FC<ExperienceEditorProps> = props => {
       <Autocomplete
         id="experience-people"
         className={styles.people}
-        value={(newExperience?.people as People[]) || []}
+        value={(newExperience?.people as People[]) ?? []}
         multiple
         options={people}
         getOptionSelected={(option, value) => option.id === value.id}
@@ -273,6 +285,7 @@ export const ExperienceEditor: React.FC<ExperienceEditorProps> = props => {
           />
         )}
         renderOption={(option, state: AutocompleteRenderOptionState) => {
+          if (option.id === '') return null;
           return (
             <ListItemComponent
               id="selectable-experience-list-item"
@@ -295,21 +308,25 @@ export const ExperienceEditor: React.FC<ExperienceEditorProps> = props => {
       />
 
       <div className={styles.preview}>
-        {newExperience?.people?.map(people => (
-          <ListItemComponent
-            id="selected-experience-list-item"
-            key={people.id}
-            title={people.name}
-            subtitle={<Typography variant="caption">@{people.username}</Typography>}
-            avatar={people.profilePictureURL}
-            size="medium"
-            action={
-              <IconButton onClick={removeSelectedPeople(people)}>
-                <SvgIcon component={XCircleIcon} color="error" />
-              </IconButton>
-            }
-          />
-        ))}
+        {newExperience?.people?.map(people =>
+          people.id === '' ? (
+            <></>
+          ) : (
+            <ListItemComponent
+              id="selected-experience-list-item"
+              key={people.id}
+              title={people.name}
+              subtitle={<Typography variant="caption">@{people.username}</Typography>}
+              avatar={people.profilePictureURL}
+              size="medium"
+              action={
+                <IconButton onClick={removeSelectedPeople(people)}>
+                  <SvgIcon component={XCircleIcon} color="error" />
+                </IconButton>
+              }
+            />
+          ),
+        )}
       </div>
       <FormControl fullWidth variant="outlined">
         <Button

--- a/src/components-v2/ExperiencePreview/ExperiencePreview.tsx
+++ b/src/components-v2/ExperiencePreview/ExperiencePreview.tsx
@@ -80,14 +80,18 @@ export const ExperiencePreview: React.FC<Props> = props => {
       </div>
       <div>
         <Typography className={style.subtitle}>{'People'}</Typography>
-        {experience.people.map(person => (
-          <ListItem key={person.id} classes={{root: style.list}}>
-            <ListItemAvatar>
-              <Avatar src={person.profilePictureURL} />
-            </ListItemAvatar>
-            <ListItemText primary={person.name} secondary={person.platform} />
-          </ListItem>
-        ))}
+        {experience.people.map(person =>
+          person.id === '' ? (
+            <></>
+          ) : (
+            <ListItem key={person.id} classes={{root: style.list}}>
+              <ListItemAvatar>
+                <Avatar src={person.profilePictureURL} />
+              </ListItemAvatar>
+              <ListItemText primary={person.name} secondary={person.platform} />
+            </ListItem>
+          ),
+        )}
       </div>
       {experience.createdBy !== userId && (
         <div className={style.button}>


### PR DESCRIPTION
# Title
- [x] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [x] Is your title relatable to the JIRA issue?
- [x] Title <= 100 characters

# Description
- Couldn't find a more elegant solution **for now**: appended an empty People object to avoid typed keywords being cleared, then this empty object got hidden

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Builds and runs on Chrome Desktop
- [x] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Have you added yourself as the Assignee?
- [x] Have you added 1 or more leads as the Reviewer?
- [x] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
