### PR TITLE
MYR-1073: check user agent exist on redirect mobile page

### DIFF
--- a/pages/experience/[experienceId]/clone.tsx
+++ b/pages/experience/[experienceId]/clone.tsx
@@ -23,22 +23,25 @@ const CloneExperience: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/experience/[experienceId]/edit.tsx
+++ b/pages/experience/[experienceId]/edit.tsx
@@ -23,22 +23,25 @@ const EditExperience: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/experience/[experienceId]/preview.tsx
+++ b/pages/experience/[experienceId]/preview.tsx
@@ -23,22 +23,25 @@ const PreviewExperience: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/experience/create.tsx
+++ b/pages/experience/create.tsx
@@ -25,22 +25,25 @@ const CreateExperience: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/friends.tsx
+++ b/pages/friends.tsx
@@ -37,22 +37,25 @@ const Friends: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -50,22 +50,25 @@ const Home: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,22 +36,23 @@ export default function Index() {
 }
 
 export const getServerSideProps: GetServerSideProps = async context => {
-  const {res} = context;
+  const {res, req} = context;
+  const {headers} = req;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -86,14 +86,18 @@ const Maintenance: React.FC = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
-  const {res} = context;
+  const {req} = context;
 
   const available = await healthcheck();
 
   if (available) {
-    res.setHeader('location', '/');
-    res.statusCode = 302;
-    res.end();
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+        headers: req.headers,
+      },
+    };
   }
 
   return {

--- a/pages/mobile.tsx
+++ b/pages/mobile.tsx
@@ -89,7 +89,10 @@ const Mobile: React.FC = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
-  if (typeof window === 'undefined') {
+  const {req} = context;
+  const {headers} = req;
+
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
     const device = new DeviceDetect();
     const {

--- a/pages/nft.tsx
+++ b/pages/nft.tsx
@@ -23,22 +23,25 @@ const NFTComponent: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/notification.tsx
+++ b/pages/notification.tsx
@@ -37,22 +37,25 @@ const Notification: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/post/[postId].tsx
+++ b/pages/post/[postId].tsx
@@ -79,24 +79,26 @@ const PostPage: React.FC<PostPageProps> = props => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
   const dispatch = store.dispatch as ThunkDispatchAction;
   const params = context.params as PostPageParams;
   let showAsDeleted = false;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -65,23 +65,25 @@ const ProfilePageComponent: React.FC<ProfilePageProps> = props => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
-  const {params} = context;
+  const {params, req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -93,22 +93,25 @@ export default function Search() {
 }
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/searchresults.tsx
+++ b/pages/searchresults.tsx
@@ -37,23 +37,24 @@ const Search: React.FC<SearchProps> = () => {
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
   const {req} = context;
+  const {headers} = req;
 
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: req.headers,
+          headers,
         },
       };
     }

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -42,22 +42,25 @@ const Settings: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/socials.tsx
+++ b/pages/socials.tsx
@@ -34,22 +34,25 @@ const Socials: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/socialtoken.tsx
+++ b/pages/socialtoken.tsx
@@ -23,22 +23,25 @@ const SocialToken: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/topic/[type].tsx
+++ b/pages/topic/[type].tsx
@@ -53,7 +53,8 @@ const Topic: React.FC<TopicPageProps> = ({experience}) => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
-  const {query} = context;
+  const {query, req} = context;
+  const {headers} = req;
   const dispatch = store.dispatch as ThunkDispatchAction;
 
   if (!['experience', 'hashtag'].includes(query.type as string)) {
@@ -62,20 +63,20 @@ export const getServerSideProps = wrapper.getServerSideProps(store => async cont
     };
   }
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/wallet.tsx
+++ b/pages/wallet.tsx
@@ -47,22 +47,25 @@ const Home: React.FC = () => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
+  const {req} = context;
+  const {headers} = req;
+
   const dispatch = store.dispatch as ThunkDispatchAction;
 
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }

--- a/pages/welcome.tsx
+++ b/pages/welcome.tsx
@@ -7,29 +7,32 @@ import {healthcheck} from 'src/lib/api/healthcheck';
 import * as UserAPI from 'src/lib/api/user';
 import {setAnonymous, setUser} from 'src/reducers/user/actions';
 import {wrapper} from 'src/store';
+import {ThunkDispatchAction} from 'src/types/thunk';
 
 const WelcomeComponentPage: React.FC = () => {
   return <WelcomeContainer />;
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async context => {
-  const {dispatch} = store;
-  const {res} = context;
+  const {req} = context;
+  const {headers} = req;
 
-  if (typeof window === 'undefined') {
+  const dispatch = store.dispatch as ThunkDispatchAction;
+
+  if (typeof window === 'undefined' && headers['user-agent']) {
     const DeviceDetect = eval('require("node-device-detector")');
 
     const device = new DeviceDetect();
     const {
       device: {type},
-    } = device.detect(context.req.headers['user-agent']);
+    } = device.detect(headers['user-agent']);
 
     if (type === 'smartphone') {
       return {
         redirect: {
           destination: '/mobile',
           permanent: false,
-          headers: context.req.headers,
+          headers,
         },
       };
     }
@@ -38,17 +41,23 @@ export const getServerSideProps = wrapper.getServerSideProps(store => async cont
   const available = await healthcheck();
 
   if (!available) {
-    res.setHeader('location', '/maintenance');
-    res.statusCode = 302;
-    res.end();
+    return {
+      redirect: {
+        destination: '/maintenance',
+        permanent: false,
+      },
+    };
   }
 
   const session = await getSession(context);
 
   if (!session) {
-    res.setHeader('location', '/');
-    res.statusCode = 302;
-    res.end();
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
   }
 
   const anonymous = Boolean(session?.user.anonymous);
@@ -57,9 +66,12 @@ export const getServerSideProps = wrapper.getServerSideProps(store => async cont
   const welcome = session?.user.welcome;
 
   if (!welcome) {
-    res.setHeader('location', '/home');
-    res.statusCode = 302;
-    res.end();
+    return {
+      redirect: {
+        destination: '/home',
+        permanent: false,
+      },
+    };
   }
 
   //TODO: this process should call thunk action creator instead of dispatch thunk acion


### PR DESCRIPTION
# check user agent exist on redirect mobile page
- [ ] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [ ] Is your title relatable to the JIRA issue?
- [ ] Title <= 100 characters

# Description

Please include a summary of the change in dot point form. Please also include relevant motivation for decisions you made and if there are any TODO items you could not complete. List any dependencies that you added (e.g. package.json).

For example:

- Filename.js: Added comment button to CommentComponent
  - I only enabled the button if the user has logged in (motivation)
  - I couldn't figure out a way to centre the button with flexbox (TODO)
- Filename2.js: bla bla bla
  - nocus dorem iptus locum
- package.json:
  - Added sharp version 2.1.0
    - Need this to compress images (motivation)
    - Tried compress-js but it's deprecated (more motivation)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Builds and runs on Chrome Desktop
- [ ] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Have you added yourself as the Assignee?
- [ ] Have you added 1 or more leads as the Reviewer?
- [ ] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
