### PR TITLE
Hid success prompt when closing modal without SendTip

### DIFF
--- a/src/components-v2/SendTip/SendTip.styles.ts
+++ b/src/components-v2/SendTip/SendTip.styles.ts
@@ -13,7 +13,7 @@ export const useStyles = makeStyles((theme: Theme) =>
     root: {
       width: 340,
       position: 'relative',
-      marginBottom: 30,
+      paddingBottom: 30,
       background: '#FFFFFF',
       boxShadow: `0px 2px 10px rgba(0, 0, 0, 0.05)`,
       borderRadius: 10,

--- a/src/components-v2/Timeline/TimelineContainer.tsx
+++ b/src/components-v2/Timeline/TimelineContainer.tsx
@@ -28,6 +28,7 @@ import {Status} from 'src/interfaces/toaster';
 import {User} from 'src/interfaces/user';
 import {RootState} from 'src/reducers';
 import {upvote, setDownvoting, deletePost, removeVote} from 'src/reducers/timeline/actions';
+import {setIsTipSent} from 'src/reducers/wallet/actions';
 import {WalletState} from 'src/reducers/wallet/reducer';
 
 type TimelineContainerProps = {
@@ -92,6 +93,8 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = props => {
     } else {
       console.log('no post tipped');
     }
+
+    dispatch(setIsTipSent(false));
 
     setTippedPost(null);
   };


### PR DESCRIPTION
# Title
- [x] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [x] Is your title relatable to the JIRA issue?
- [x] Title <= 100 characters

# Description
- Closed success prompt when closing modal without sending tip

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Builds and runs on Chrome Desktop
- [x] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Have you added yourself as the Assignee?
- [x] Have you added 1 or more leads as the Reviewer?
- [x] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
