### PR TITLE
Revised receiver name when tipping to imported posts

### DIFF
--- a/src/components-v2/Timeline/TimelineContainer.tsx
+++ b/src/components-v2/Timeline/TimelineContainer.tsx
@@ -192,7 +192,9 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = props => {
           <Typography component="div">
             Tip to{' '}
             <Box fontWeight={700} display="inline">
-              {tippedContentForHistory?.user.name ?? 'Unknown Myrian'}
+              {tippedContentForHistory?.importers && tippedContentForHistory?.importers.length > 0
+                ? tippedContentForHistory?.people?.name
+                : tippedContentForHistory?.user.name ?? 'Unknown Myrian'}
             </Box>{' '}
             sent successfully
           </Typography>

--- a/src/components-v2/atoms/PostHeader/subHeader/post-sub-header.component.tsx
+++ b/src/components-v2/atoms/PostHeader/subHeader/post-sub-header.component.tsx
@@ -25,13 +25,14 @@ export const PostSubHeader: React.FC<PostSubHeaderProps> = ({
 
   return (
     <Typography component="div" className={style.root}>
-      <ShowIf condition={platform !== 'myriad'}>Imported on&nbsp;</ShowIf>
-
-      <Link href={`/post/${postId}`}>
-        <a href={`/post/${postId}`} className={style.linkGrey}>
-          {getDate(date)}
-        </a>
-      </Link>
+      <ShowIf condition={platform === 'myriad'}>
+        Imported on&nbsp;
+        <Link href={`/post/${postId}`}>
+          <a href={`/post/${postId}`} className={style.linkGrey}>
+            {getDate(date)}
+          </a>
+        </Link>
+      </ShowIf>
 
       <ShowIf condition={platform !== 'myriad'}>
         {importers && importers.length && (


### PR DESCRIPTION
# Title
- [x] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [x] Is your title relatable to the JIRA issue?
- [x] Title <= 100 characters

# Description
- Simple logic checking whether a post has `importers` field or not, to make sure success prompt displays receiver's name correctly.
- Small fix on subtext `created on...` on PostHeader. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Builds and runs on Chrome Desktop
- [x] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Have you added yourself as the Assignee?
- [x] Have you added 1 or more leads as the Reviewer?
- [x] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
