### PR TITLE
fix showing option subscribe and edit experience on the experience card

### DIFF
--- a/src/components/ExperienceList/ExperienceList.tsx
+++ b/src/components/ExperienceList/ExperienceList.tsx
@@ -13,6 +13,7 @@ const ExperienceList: React.FC<ExperienceListProps> = ({
   user,
   viewPostList,
   onDelete,
+  onUnsubscribe,
 }) => {
   const classes = useStyles();
 
@@ -55,11 +56,13 @@ const ExperienceList: React.FC<ExperienceListProps> = ({
             onSelect={handleClick}
             title={item.experience.name}
             creator={item.experience.user.name}
+            subscribed={item.subscribed}
             imgUrl={item.experience.experienceImageURL || ''}
             experienceId={item.experienceId}
             userExperienceId={item.id}
             isSelectable={selectable}
             onDelete={onDelete}
+            onUnsubscribe={onUnsubscribe}
             selected={selected}
           />
         </div>

--- a/src/components/ExperienceList/experience-list.interfaces.ts
+++ b/src/components/ExperienceList/experience-list.interfaces.ts
@@ -11,6 +11,7 @@ interface ExperienceListProps {
   onFollow?: (experienceId: string) => void;
   onPreview?: (experienceId: string) => void;
   onDelete?: (experienceId: string) => void;
+  onUnsubscribe?: (experienceId: string) => void;
 }
 
 interface NonSelectableExperienceList {

--- a/src/components/ExperienceTabMenu/ExperienceTabMenu.tsx
+++ b/src/components/ExperienceTabMenu/ExperienceTabMenu.tsx
@@ -43,10 +43,11 @@ interface ExperienceTabMenuProps {
   viewPostList: (type: TimelineType, experience: Experience) => void;
   filterExperience: (sort: string) => void;
   onDelete: (experienceId: string) => void;
+  onUnsubscribe: (experienceId: string) => void;
 }
 
 export const ExperienceTabMenu: React.FC<ExperienceTabMenuProps> = props => {
-  const {experiences, user, viewPostList, filterExperience, onDelete} = props;
+  const {experiences, user, viewPostList, filterExperience, onDelete, onUnsubscribe} = props;
   const style = useStyles();
 
   return (
@@ -55,6 +56,7 @@ export const ExperienceTabMenu: React.FC<ExperienceTabMenuProps> = props => {
       <HeaderWithAction filter={filterExperience} actionText={'+ Create experience'} />
       <ExperienceList
         onDelete={onDelete}
+        onUnsubscribe={onUnsubscribe}
         viewPostList={viewPostList}
         experiences={experiences}
         user={user}

--- a/src/components/ExperienceTabMenu/ExperienceTabMenuContainer.tsx
+++ b/src/components/ExperienceTabMenu/ExperienceTabMenuContainer.tsx
@@ -34,7 +34,8 @@ export const ExperienceTabMenuContainer: React.FC = () => {
   const router = useRouter();
 
   // Only load experiences specific to logged user
-  const {loadExperience, experiences, removeExperience} = useExperienceHook();
+  const {loadExperience, experiences, removeExperience, unsubscribeExperience} =
+    useExperienceHook();
   const [myExperience, setMyExperience] = useState<UserExperience[]>([]);
 
   useEffect(() => {
@@ -92,6 +93,12 @@ export const ExperienceTabMenuContainer: React.FC = () => {
     });
   };
 
+  const handleUnsubscribeExperience = (experienceId: string) => {
+    unsubscribeExperience(experienceId, () => {
+      loadExperience();
+    });
+  };
+
   if (anonymous)
     return (
       <>
@@ -109,6 +116,7 @@ export const ExperienceTabMenuContainer: React.FC = () => {
       experiences={myExperience}
       user={user}
       onDelete={handleRemoveExperience}
+      onUnsubscribe={handleUnsubscribeExperience}
     />
   );
 };

--- a/src/components/atoms/SimpleCard/SimpleCard.tsx
+++ b/src/components/atoms/SimpleCard/SimpleCard.tsx
@@ -19,14 +19,18 @@ import {useStyles, SimpleCardProps} from '.';
 import {TimelineType} from '../../../interfaces/timeline';
 import {PromptComponent} from '../Prompt/prompt.component';
 
+import ShowIf from 'src/components/common/show-if.component';
+
 const SimpleCard: React.FC<SimpleCardProps> = ({
   user,
   creator,
   title,
   imgUrl,
   isSelectable,
+  subscribed = false,
   filterTimeline,
   onDelete,
+  onUnsubscribe,
   experienceId,
   userExperienceId,
   selected,
@@ -58,6 +62,13 @@ const SimpleCard: React.FC<SimpleCardProps> = ({
   const handleRemove = () => {
     if (userExperienceId && onDelete) onDelete(userExperienceId);
     handleCancel();
+    handleClose();
+  };
+
+  const handleUnsubscribe = () => {
+    if (userExperienceId && onUnsubscribe) {
+      onUnsubscribe(userExperienceId);
+    }
     handleClose();
   };
 
@@ -139,12 +150,26 @@ const SimpleCard: React.FC<SimpleCardProps> = ({
         <Link href={`/experience/${experienceId}/preview`}>
           <MenuItem>See details</MenuItem>
         </Link>
-        <Link href={`/experience/${experienceId}/edit`}>
-          <MenuItem>Edit experience</MenuItem>
-        </Link>
-        <MenuItem onClick={handleOpen} className={classes.delete}>
-          Delete
-        </MenuItem>
+        <ShowIf condition={subscribed}>
+          <Link href={`/experience/${experienceId}/clone`}>
+            <MenuItem>Clone</MenuItem>
+          </Link>
+        </ShowIf>
+        <ShowIf condition={!subscribed}>
+          <Link href={`/experience/${experienceId}/edit`}>
+            <MenuItem>Edit experience</MenuItem>
+          </Link>
+        </ShowIf>
+        <ShowIf condition={subscribed}>
+          <MenuItem onClick={handleUnsubscribe} className={classes.delete}>
+            Unsubscribe
+          </MenuItem>
+        </ShowIf>
+        <ShowIf condition={!subscribed}>
+          <MenuItem onClick={handleOpen} className={classes.delete}>
+            Delete
+          </MenuItem>
+        </ShowIf>
       </Menu>
       <PromptComponent
         onCancel={handleCancel}

--- a/src/components/atoms/SimpleCard/simple-card.interfaces.ts
+++ b/src/components/atoms/SimpleCard/simple-card.interfaces.ts
@@ -22,12 +22,14 @@ interface SimpleCardProps {
   experienceId?: string;
   userExperienceId?: string;
   selected?: string | undefined;
+  subscribed?: boolean;
   filterTimeline: (type: TimelineType) => void;
   onSelect?: (id: string) => void;
   onSubscribe?: (experienceId: string) => void;
   onFollow?: (experienceId: string) => void;
   onPreview?: (experienceId: string) => void;
   onDelete?: (experienceId: string) => void;
+  onUnsubscribe?: (experienceId: string) => void;
 }
 
 type NonSelectableSimpleCardProps = Omit<SimpleCardProps, 'filterTimeline' | 'onClick'>;

--- a/src/hooks/use-experience-hook.ts
+++ b/src/hooks/use-experience-hook.ts
@@ -15,6 +15,7 @@ import {
   subscribeExperience,
   updateExperience,
   deleteExperience,
+  unsubscribeExperience,
 } from '../reducers/experience/actions';
 import {ExperienceState} from '../reducers/experience/reducer';
 
@@ -119,6 +120,14 @@ export const useExperienceHook = () => {
     dispatch(deleteExperience(experienceId, callback));
   };
 
+  const beUnsubscribeExperience = (experienceId: string, callback?: () => void) => {
+    dispatch(
+      unsubscribeExperience(experienceId, () => {
+        loadExperience();
+      }),
+    );
+  };
+
   return {
     searchPeople: findPeople,
     searchExperience: findExperience,
@@ -138,5 +147,6 @@ export const useExperienceHook = () => {
     subscribeExperience: beSubscribeExperience,
     updateExperience: editExperience,
     removeExperience,
+    unsubscribeExperience: beUnsubscribeExperience,
   };
 };

--- a/src/lib/api/experience.ts
+++ b/src/lib/api/experience.ts
@@ -146,6 +146,13 @@ export const subscribeExperience = async (userId: string, experienceId: string):
   });
 };
 
+export const unsubscribeExperience = async (userExperienceId: string): Promise<void> => {
+  await MyriadAPI.request<Experience>({
+    url: `/user-experiences/${userExperienceId}`,
+    method: 'DELETE',
+  });
+};
+
 export const updateExperience = async (
   userId: string,
   experienceId: string,

--- a/src/reducers/experience/actions.ts
+++ b/src/reducers/experience/actions.ts
@@ -431,3 +431,36 @@ export const deleteExperience: ThunkActionCreator<Actions, RootState> =
       dispatch(setLoading(false));
     }
   };
+
+export const unsubscribeExperience: ThunkActionCreator<Actions, RootState> =
+  (experienceId: string, callback?: () => void) => async (dispatch, getState) => {
+    dispatch(setLoading(true));
+    try {
+      const {
+        userState: {user},
+      } = getState();
+
+      if (!user) {
+        throw new Error('User not found');
+      }
+
+      await ExperienceAPI.unsubscribeExperience(experienceId);
+
+      callback && callback();
+
+      await dispatch(
+        showToasterSnack({
+          variant: 'success',
+          message: 'unsubscribed successfully!',
+        }),
+      );
+    } catch (error) {
+      dispatch(
+        setError({
+          message: error.message,
+        }),
+      );
+    } finally {
+      dispatch(setLoading(false));
+    }
+  };


### PR DESCRIPTION
# Title
- [ ] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [ ] Is your title relatable to the JIRA issue?
- [ ] Title <= 100 characters

# Description

add unsubscribe action for the experience that has been subscribed, the card added more props called onUnsubscribed and subscribed so it can detect and showing the option based on the subscribed value, has been tested and there's some problem on API giving the 404 error code but the experience that has been unsubscribed has been remove from the list of experience list.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Builds and runs on Chrome Desktop
- [ ] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Have you added yourself as the Assignee?
- [ ] Have you added 1 or more leads as the Reviewer?
- [ ] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
