### PR TITLE
fix showing image when edit experience

### DIFF
--- a/src/components/ExperienceEditor/ExperienceEditor.tsx
+++ b/src/components/ExperienceEditor/ExperienceEditor.tsx
@@ -129,6 +129,8 @@ export const ExperienceEditor: React.FC<ExperienceEditorProps> = props => {
       setIsloading(false);
       setImage(url);
       setNewExperience({...newExperience, experienceImageURL: url});
+    } else {
+      setNewExperience({...newExperience, experienceImageURL: undefined});
     }
   };
 
@@ -235,7 +237,7 @@ export const ExperienceEditor: React.FC<ExperienceEditorProps> = props => {
         <InputLabel htmlFor="experience-picture" shrink={true} className={styles.label}>
           Picture
         </InputLabel>
-        <Dropzone onImageSelected={handleImageUpload} value={image} maxSize={3} />
+        <Dropzone onImageSelected={handleImageUpload} value={image} maxSize={3} isEdit={true} />
         <ShowIf condition={isLoading}>
           <div className={styles.loading}>
             <CircularProgress size={32} color="primary" />

--- a/src/components/atoms/Dropzone/Dropzone.tsx
+++ b/src/components/atoms/Dropzone/Dropzone.tsx
@@ -33,6 +33,7 @@ type DropzoneProps = {
   maxSize?: number;
   multiple?: boolean;
   usage?: string;
+  isEdit?: boolean;
   onImageSelected: (files: File[]) => void;
 };
 
@@ -55,6 +56,7 @@ export const Dropzone: React.FC<DropzoneProps> = props => {
     border = true,
     placeholder = 'File must be .jpeg or .png',
     usage = '',
+    isEdit = false,
   } = props;
   const styles = useStyles({border});
 
@@ -66,9 +68,9 @@ export const Dropzone: React.FC<DropzoneProps> = props => {
 
   useEffect(() => {
     if (value) {
-      setPreview(prevPreview => [...prevPreview, value]);
+      setPreview([value]);
     }
-  }, []);
+  }, [value]);
 
   const {getRootProps, getInputProps, open} = useDropzone({
     accept,
@@ -213,14 +215,20 @@ export const Dropzone: React.FC<DropzoneProps> = props => {
     );
   };
 
-  const removeFile = (index: number) => {
-    const currentFiles = files.filter((file, i) => index !== i);
-    const currentPreview = preview.filter((url, i) => index !== i);
+  const removeFile = (index?: number) => {
+    if (isEdit) {
+      setPreview([]);
+      const currentFiles = files.filter((file, i) => index !== -1);
+      onImageSelected(currentFiles);
+    } else {
+      const currentFiles = files.filter((file, i) => index !== i);
+      const currentPreview = preview.filter((url, i) => index !== i);
 
-    setFiles(currentFiles);
-    setPreview(currentPreview);
+      setFiles(currentFiles);
+      setPreview(currentPreview);
 
-    onImageSelected(currentFiles);
+      onImageSelected(currentFiles);
+    }
   };
 
   const handleReuploadImage = () => {
@@ -259,6 +267,21 @@ export const Dropzone: React.FC<DropzoneProps> = props => {
         <input {...getInputProps()} />
         {preview.length ? (
           <>
+            <ShowIf condition={isEdit}>
+              <img
+                style={{visibility: 'visible'}}
+                src={preview[0]}
+                alt=""
+                className={styles.image}
+              />
+              <IconButton
+                size="small"
+                aria-label={`remove image`}
+                className={styles.icon}
+                onClick={() => removeFile()}>
+                <SvgIcon component={XIcon} style={{fontSize: '1rem'}} />
+              </IconButton>
+            </ShowIf>
             <ShowIf condition={type === 'image'}>
               <ImageList rowHeight={128} cols={6} className={styles.preview}>
                 {files.map((item, i) => (
@@ -330,7 +353,7 @@ export const Dropzone: React.FC<DropzoneProps> = props => {
           </>
         )}
 
-        {!loading && (
+        {!loading && preview.length === 0 && (
           <Button
             className={styles.button}
             size="small"


### PR DESCRIPTION
# Title
- [x] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [x] Is your title relatable to the JIRA issue?
- [x] Title <= 100 characters

# Description

add isEdit props and show the image based on the experience image URL.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Builds and runs on Chrome Desktop
- [x] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Have you added yourself as the Assignee?
- [x] Have you added 1 or more leads as the Reviewer?
- [x] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
