### PR TITLE
showing toast when experience on max limit

### DIFF
--- a/src/components/ExperienceList/ExperienceList.tsx
+++ b/src/components/ExperienceList/ExperienceList.tsx
@@ -14,6 +14,7 @@ const ExperienceList: React.FC<ExperienceListProps> = ({
   viewPostList,
   onDelete,
   onUnsubscribe,
+  onFollow,
 }) => {
   const classes = useStyles();
 
@@ -29,7 +30,6 @@ const ExperienceList: React.FC<ExperienceListProps> = ({
   };
 
   const handleViewExperience = (experience: Experience) => (type: TimelineType) => {
-    console.log('handleViewExperience', experience);
     viewPostList(type, experience);
   };
 
@@ -63,6 +63,7 @@ const ExperienceList: React.FC<ExperienceListProps> = ({
             isSelectable={selectable}
             onDelete={onDelete}
             onUnsubscribe={onUnsubscribe}
+            onFollow={onFollow}
             selected={selected}
           />
         </div>

--- a/src/components/ExperienceList/SearchedExperienceListContainer.tsx
+++ b/src/components/ExperienceList/SearchedExperienceListContainer.tsx
@@ -5,6 +5,8 @@ import {useRouter} from 'next/router';
 import {SearchedExperienceList} from '.';
 import {useExperienceHook} from '../../hooks/use-experience-hook';
 
+import {useToasterSnackHook} from 'src/hooks/use-toaster-snack.hook';
+
 export const SearchedExperienceListContainer: React.FC = () => {
   const {
     searchedExperiences,
@@ -12,10 +14,18 @@ export const SearchedExperienceListContainer: React.FC = () => {
     unsubscribeExperience,
     experiences: userExperience,
   } = useExperienceHook();
+  const {openToasterSnack} = useToasterSnackHook();
   const router = useRouter();
 
   const handleSubsibeExperience = (experienceId: string) => {
-    subscribeExperience(experienceId);
+    if (userExperience.length === 10) {
+      openToasterSnack({
+        message: 'You can only add up to 10 experiences max',
+        variant: 'warning',
+      });
+    } else {
+      subscribeExperience(experienceId);
+    }
   };
 
   const handleUnsubscribeExperience = (experienceId: string) => {
@@ -23,7 +33,14 @@ export const SearchedExperienceListContainer: React.FC = () => {
   };
 
   const handleCloneExperience = (experienceId: string) => {
-    router.push(`/experience/${experienceId}/clone`);
+    if (userExperience.length === 10) {
+      openToasterSnack({
+        message: 'You can only add up to 10 experiences max',
+        variant: 'warning',
+      });
+    } else {
+      router.push(`/experience/${experienceId}/clone`);
+    }
   };
 
   const handlePreviewExperience = (experienceId: string) => {

--- a/src/components/ExperiencePreview/ExperiencePreview.container.tsx
+++ b/src/components/ExperiencePreview/ExperiencePreview.container.tsx
@@ -8,6 +8,7 @@ import {useStyles} from './experience.style';
 
 import {TopNavbarComponent, SectionTitle} from 'src/components/atoms/TopNavbar';
 import {useExperienceHook} from 'src/hooks/use-experience-hook';
+import {useToasterSnackHook} from 'src/hooks/use-toaster-snack.hook';
 import {RootState} from 'src/reducers';
 import {UserState} from 'src/reducers/user/reducer';
 
@@ -20,6 +21,7 @@ export const ExperiencePreviewContainer: React.FC = () => {
     subscribeExperience,
     unsubscribeExperience,
   } = useExperienceHook();
+  const {openToasterSnack} = useToasterSnackHook();
   const style = useStyles();
   const router = useRouter();
   const {experienceId} = router.query;
@@ -29,7 +31,14 @@ export const ExperiencePreviewContainer: React.FC = () => {
   }, [experienceId]);
 
   const handleSubscribeExperience = (experienceId: string) => {
-    subscribeExperience(experienceId);
+    if (userExperience.length === 10) {
+      openToasterSnack({
+        message: 'You can only add up to 10 experiences max',
+        variant: 'warning',
+      });
+    } else {
+      subscribeExperience(experienceId);
+    }
   };
 
   const handleUnsubscribeExperience = (userExperienceId: string) => {
@@ -37,7 +46,14 @@ export const ExperiencePreviewContainer: React.FC = () => {
   };
 
   const handleCloneExperience = (experienceId: string) => {
-    router.push(`/experience/${experienceId}/clone`);
+    if (userExperience.length === 10) {
+      openToasterSnack({
+        message: 'You can only add up to 10 experiences max',
+        variant: 'warning',
+      });
+    } else {
+      router.push(`/experience/${experienceId}/clone`);
+    }
   };
 
   const handleEditExperience = (experienceId: string) => {

--- a/src/components/ExperienceTabMenu/ExperienceTabMenu.tsx
+++ b/src/components/ExperienceTabMenu/ExperienceTabMenu.tsx
@@ -43,19 +43,30 @@ interface ExperienceTabMenuProps {
   viewPostList: (type: TimelineType, experience: Experience) => void;
   onDelete: (experienceId: string) => void;
   onUnsubscribe: (experienceId: string) => void;
+  onCloneExperience: (experienceId: string) => void;
+  onCreateExperience: () => void;
 }
 
 export const ExperienceTabMenu: React.FC<ExperienceTabMenuProps> = props => {
-  const {experiences, user, viewPostList, onDelete, onUnsubscribe} = props;
+  const {
+    experiences,
+    user,
+    viewPostList,
+    onDelete,
+    onUnsubscribe,
+    onCreateExperience,
+    onCloneExperience,
+  } = props;
   const style = useStyles();
 
   return (
     <>
       <Typography variant={'h4'}>Experience</Typography>
-      <HeaderWithAction actionText={'+ Create experience'} />
+      <HeaderWithAction actionText={'+ Create experience'} onClick={onCreateExperience} />
       <ExperienceList
         onDelete={onDelete}
         onUnsubscribe={onUnsubscribe}
+        onFollow={onCloneExperience}
         viewPostList={viewPostList}
         experiences={experiences}
         user={user}

--- a/src/components/ExperienceTabMenu/ExperienceTabMenuContainer.tsx
+++ b/src/components/ExperienceTabMenu/ExperienceTabMenuContainer.tsx
@@ -9,6 +9,7 @@ import {createStyles, makeStyles, Theme} from '@material-ui/core/styles';
 import {ExperienceTabMenu} from './ExperienceTabMenu';
 
 import {useExperienceHook} from 'src/hooks/use-experience-hook';
+import {useToasterSnackHook} from 'src/hooks/use-toaster-snack.hook';
 import {Experience, UserExperience} from 'src/interfaces/experience';
 import {TimelineType} from 'src/interfaces/timeline';
 import {RootState} from 'src/reducers';
@@ -35,6 +36,7 @@ export const ExperienceTabMenuContainer: React.FC = () => {
   // Only load experiences specific to logged user
   const {loadExperience, experiences, removeExperience, unsubscribeExperience} =
     useExperienceHook();
+  const {openToasterSnack} = useToasterSnackHook();
   const [myExperience, setMyExperience] = useState<UserExperience[]>([]);
 
   useEffect(() => {
@@ -64,6 +66,28 @@ export const ExperienceTabMenuContainer: React.FC = () => {
     });
   };
 
+  const handleCloneExperience = (experienceId: string) => {
+    if (experiences.length === 10) {
+      openToasterSnack({
+        message: 'You can only add up to 10 experiences max',
+        variant: 'warning',
+      });
+    } else {
+      router.push(`/experience/${experienceId}/clone`);
+    }
+  };
+
+  const handleCreateExperience = () => {
+    if (experiences.length === 10) {
+      openToasterSnack({
+        message: 'You can only add up to 10 experiences max',
+        variant: 'warning',
+      });
+    } else {
+      router.push('/experience/create');
+    }
+  };
+
   if (anonymous)
     return (
       <>
@@ -81,6 +105,8 @@ export const ExperienceTabMenuContainer: React.FC = () => {
       user={user}
       onDelete={handleRemoveExperience}
       onUnsubscribe={handleUnsubscribeExperience}
+      onCreateExperience={handleCreateExperience}
+      onCloneExperience={handleCloneExperience}
     />
   );
 };

--- a/src/components/HeaderWithAction/HeaderWithAction.tsx
+++ b/src/components/HeaderWithAction/HeaderWithAction.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 
-import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
 
 import {useStyles, HeaderWithActionProps} from '.';
 
 export const HeaderWithAction: React.FC<HeaderWithActionProps> = props => {
-  const {actionText} = props;
+  const {actionText, onClick} = props;
   const classes = useStyles();
 
   return (
     <div className={classes.root}>
-      <Typography variant={'caption'} color={'primary'}>
-        <Link href={'/experience/create'} className={classes.actionText}>
-          {actionText}
-        </Link>
+      <Typography
+        variant={'caption'}
+        color={'primary'}
+        className={classes.actionText}
+        onClick={onClick}>
+        {actionText}
       </Typography>
     </div>
   );

--- a/src/components/HeaderWithAction/header-w-action.interfaces.ts
+++ b/src/components/HeaderWithAction/header-w-action.interfaces.ts
@@ -1,5 +1,6 @@
 interface HeaderWithActionProps {
   actionText: string;
+  onClick: () => void;
 }
 
 export type {HeaderWithActionProps};

--- a/src/components/HeaderWithAction/header-w-action.styles.ts
+++ b/src/components/HeaderWithAction/header-w-action.styles.ts
@@ -18,6 +18,10 @@ export const useStyles = makeStyles((theme: Theme) =>
     actionText: {
       fontFamily: ['Mulish', 'serif'].join(','),
       fontWeight: theme.typography.fontWeightMedium,
+      cursor: 'pointer',
+      '&:hover': {
+        textDecoration: 'underline',
+      },
     },
   }),
 );

--- a/src/components/Profile/ExperienceTabPanel/ExperienceTabPanel.container.tsx
+++ b/src/components/Profile/ExperienceTabPanel/ExperienceTabPanel.container.tsx
@@ -7,6 +7,7 @@ import {useExperienceHook} from '../../../hooks/use-experience-hook';
 import {ExperienceTabPanel} from './ExperienceTabPanel';
 
 import {ExperienceType} from 'src/components/Timeline/default';
+import {useToasterSnackHook} from 'src/hooks/use-toaster-snack.hook';
 import {UserExperience} from 'src/interfaces/experience';
 import {User} from 'src/interfaces/user';
 import {RootState} from 'src/reducers';
@@ -24,6 +25,7 @@ export const ExperienceTabPanelContainer: React.FC<ExperienceTabPanelContainerPr
     unsubscribeExperience,
     experiences: userExperience,
   } = useExperienceHook();
+  const {openToasterSnack} = useToasterSnackHook();
   const router = useRouter();
 
   const dispatch = useDispatch();
@@ -47,7 +49,14 @@ export const ExperienceTabPanelContainer: React.FC<ExperienceTabPanelContainerPr
   };
 
   const handleSubsibeExperience = (experienceId: string) => {
-    subscribeExperience(experienceId);
+    if (userExperience.length === 10) {
+      openToasterSnack({
+        message: 'You can only add up to 10 experiences max',
+        variant: 'warning',
+      });
+    } else {
+      subscribeExperience(experienceId);
+    }
   };
 
   const handleUnsubscribeExperience = (experienceId: string) => {
@@ -55,7 +64,14 @@ export const ExperienceTabPanelContainer: React.FC<ExperienceTabPanelContainerPr
   };
 
   const handleCloneExperience = (experienceId: string) => {
-    router.push(`/experience/${experienceId}/clone`);
+    if (userExperience.length === 10) {
+      openToasterSnack({
+        message: 'You can only add up to 10 experiences max',
+        variant: 'warning',
+      });
+    } else {
+      router.push(`/experience/${experienceId}/clone`);
+    }
   };
 
   const handlePreviewExperience = (experienceId: string) => {

--- a/src/components/Search/SearchResultContainer.tsx
+++ b/src/components/Search/SearchResultContainer.tsx
@@ -112,6 +112,7 @@ export const SearchResultContainer: React.FC = () => {
         active={searchResultTabTexts[0].id}
         tabs={searchResultTabTexts}
         mark="underline"
+        background={selectedTab === 'users-tab' ? 'white' : 'transparent'}
         position="left"
         size="medium"
         padding={selectedTab === 'experience-tab' ? 0 : 3.75}

--- a/src/components/atoms/Dropzone/Dropzone.tsx
+++ b/src/components/atoms/Dropzone/Dropzone.tsx
@@ -275,23 +275,12 @@ export const Dropzone: React.FC<DropzoneProps> = props => {
         {preview.length ? (
           <>
             <ShowIf condition={isEdit && !isFileRemoved && editorType !== ''}>
-              <ImageList rowHeight={128} cols={6} className={styles.preview}>
-                <ImageListItem cols={getCols()} rows={getRows()} classes={{item: styles.item}}>
-                  <img
-                    style={{visibility: 'visible'}}
-                    src={preview[0]}
-                    alt=""
-                    className={styles.image}
-                  />
-                  <IconButton
-                    size="small"
-                    aria-label={`remove image`}
-                    className={styles.icon}
-                    onClick={() => removeFile()}>
-                    <SvgIcon component={XIcon} style={{fontSize: '1rem'}} />
-                  </IconButton>
-                </ImageListItem>
-              </ImageList>
+              <img
+                style={{visibility: 'visible'}}
+                src={preview[0]}
+                alt=""
+                className={styles.image}
+              />
             </ShowIf>
             <ShowIf condition={type === 'image' && !isEdit}>
               <ShowIf condition={!multiple}>

--- a/src/components/atoms/SimpleCard/SimpleCard.tsx
+++ b/src/components/atoms/SimpleCard/SimpleCard.tsx
@@ -31,6 +31,7 @@ const SimpleCard: React.FC<SimpleCardProps> = ({
   filterTimeline,
   onDelete,
   onUnsubscribe,
+  onFollow,
   experienceId,
   userExperienceId,
   selected,
@@ -68,6 +69,13 @@ const SimpleCard: React.FC<SimpleCardProps> = ({
   const handleUnsubscribe = () => {
     if (userExperienceId && onUnsubscribe) {
       onUnsubscribe(userExperienceId);
+    }
+    handleClose();
+  };
+
+  const handleClone = () => {
+    if (experienceId && onFollow) {
+      onFollow(experienceId);
     }
     handleClose();
   };
@@ -151,9 +159,7 @@ const SimpleCard: React.FC<SimpleCardProps> = ({
           <MenuItem>See details</MenuItem>
         </Link>
         <ShowIf condition={subscribed}>
-          <Link href={`/experience/${experienceId}/clone`}>
-            <MenuItem>Clone</MenuItem>
-          </Link>
+          <MenuItem onClick={handleClone}>Clone</MenuItem>
         </ShowIf>
         <ShowIf condition={!subscribed}>
           <Link href={`/experience/${experienceId}/edit`}>


### PR DESCRIPTION
# Title
- [x] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [x] Is your title relatable to the JIRA issue?
- [x] Title <= 100 characters

# Description

add a condition to check for how many experiences (max limit is 10) before doing an action to add (like subscribe, clone, or create) and showing the toaster if it's already reach it's limit

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Builds and runs on Chrome Desktop
- [ ] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Have you added yourself as the Assignee?
- [x] Have you added 1 or more leads as the Reviewer?
- [x] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
