### PR TITLE
myr-1505: fix ux on handling save profile

### DIFF
--- a/src/components/Profile/edit/ProfileEdit.tsx
+++ b/src/components/Profile/edit/ProfileEdit.tsx
@@ -75,7 +75,7 @@ export const ProfileEditComponent: React.FC<Props> = props => {
     } else {
       setIsUpdateProfile(false);
     }
-  }, [newUser, imageProfile]);
+  }, [newUser, imageProfile, imageBanner]);
 
   const handleChange = (field: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
     setNewUser(prevUser => ({

--- a/src/components/Profile/edit/ProfileEdit.tsx
+++ b/src/components/Profile/edit/ProfileEdit.tsx
@@ -57,13 +57,25 @@ export const ProfileEditComponent: React.FC<Props> = props => {
   const [open, setOpen] = useState(false);
   const [openConfirmation, setOpenConfirmation] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [isUpdateProfile, setIsUpdateProfile] = useState(false);
 
   const style = useStyles();
 
   useEffect(() => {
     handleChanges();
     nameValidation();
-  }, [newUser]);
+    if (
+      user?.bio !== newUser.bio ||
+      user?.name !== newUser.name ||
+      user?.websiteURL !== newUser?.websiteURL ||
+      imageProfile instanceof File ||
+      imageBanner instanceof File
+    ) {
+      setIsUpdateProfile(true);
+    } else {
+      setIsUpdateProfile(false);
+    }
+  }, [newUser, imageProfile]);
 
   const handleChange = (field: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
     setNewUser(prevUser => ({
@@ -271,7 +283,7 @@ export const ProfileEditComponent: React.FC<Props> = props => {
             color="primary"
             disableElevation
             onClick={saveConfirmation}
-            disabled={isError || handleError() || updatingProfile}
+            disabled={isError || handleError() || updatingProfile || !isUpdateProfile}
             classes={{root: style.width}}>
             Save changes
           </Button>


### PR DESCRIPTION
# Title
- [x] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [x] Is your title relatable to the JIRA issue?
- [x] Title <= 100 characters

# Description

The save button on the edit profile should be active when there's some change on the field (either the field or the image) so now just listen to the changes on the value and set the state for isUpdateProfile

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Builds and runs on Chrome Desktop
- [ ] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Have you added yourself as the Assignee?
- [ ] Have you added 1 or more leads as the Reviewer?
- [ ] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
