### PR TITLE
Fixed shown balance length to 4 decimal place

### DIFF
--- a/src/components/BalanceDetailList/BalanceDetailList.tsx
+++ b/src/components/BalanceDetailList/BalanceDetailList.tsx
@@ -133,7 +133,7 @@ export const BalanceDetailList: React.FC<BalanceDetailListProps> = props => {
                   <TableCell align="right">
                     <div>
                       <Typography variant="body1" style={{fontWeight: 'bold'}}>
-                        {balanceDetail.freeBalance}
+                        {parseFloat(balanceDetail.freeBalance.toFixed(4))}
                       </Typography>
                       <Typography variant="caption" color="textSecondary">
                         {`~${formatUsd(

--- a/src/components/HistoryDetailList/HistoryDetailList.tsx
+++ b/src/components/HistoryDetailList/HistoryDetailList.tsx
@@ -164,6 +164,17 @@ export const HistoryDetailList: React.FC<HistoryDetailListProps> = props => {
     return timeAgoInString;
   };
 
+  const parseScientificNotatedNumber = (input: number) => {
+    let result: string | null = null;
+    const parsedInput = input.toString().split('-')[1];
+
+    if (parsedInput) result = input.toFixed(Number(parsedInput));
+
+    if (parsedInput === undefined) result = input.toString();
+
+    return result;
+  };
+
   const namePlaceholder = 'Unknown Myrian';
 
   return (
@@ -244,12 +255,12 @@ export const HistoryDetailList: React.FC<HistoryDetailListProps> = props => {
                         <div>
                           {tx.toUser?.id === userId && (
                             <Typography variant="h5" className={classes.textAmountGreen}>
-                              +{tx.amount} {tx.currency.id}
+                              +{parseScientificNotatedNumber(tx.amount)} {tx.currency.id}
                             </Typography>
                           )}
                           {tx.fromUser?.id === userId && (
                             <Typography variant="h5" className={classes.textAmountRed}>
-                              -{tx.amount} {tx.currency.id}
+                              -{parseScientificNotatedNumber(tx.amount)} {tx.currency.id}
                             </Typography>
                           )}
                           <Typography variant="caption" color="textSecondary">

--- a/src/components/PrimaryCoinMenu/DraggableBalanceCard.tsx
+++ b/src/components/PrimaryCoinMenu/DraggableBalanceCard.tsx
@@ -59,7 +59,7 @@ export const DraggableBalanceCard: React.FC<DraggableBalanceCardProps> = props =
           <div className={classes.rightJustifiedWrapper}>
             <div style={{textAlign: 'right'}}>
               <Typography variant="body1" style={{fontWeight: 'bold'}}>
-                {balanceDetail.freeBalance}
+                {parseFloat(balanceDetail.freeBalance.toFixed(4))}
               </Typography>
               <Typography variant="caption" color="textSecondary">
                 {`~${formatUsd(balanceDetail.freeBalance, getConversion(balanceDetail.id))} USD`}

--- a/src/components/SendTip/SendTip.tsx
+++ b/src/components/SendTip/SendTip.tsx
@@ -201,7 +201,7 @@ export const SendTip: React.FC<SendTipProps> = ({balanceDetails, tippedUser, tip
             <ListItemComponent
               avatar={selectedCurrency.image}
               title={selectedCurrency.id}
-              subtitle={selectedCurrency.freeBalance}
+              subtitle={parseFloat(selectedCurrency.freeBalance.toFixed(4))}
               action={
                 <CurrencyOptionComponent
                   onSelect={setSelectedCurrency}

--- a/src/components/WalletBalance/index.tsx
+++ b/src/components/WalletBalance/index.tsx
@@ -48,7 +48,9 @@ export const WalletBalances: React.FC<WalletProps> = ({balances}) => {
           key={balance.id}
           title={balance.id}
           avatar={balance.image}
-          action={<Typography variant="h5">{balance.freeBalance}</Typography>}
+          action={
+            <Typography variant="h5">{parseFloat(balance.freeBalance.toFixed(4))}</Typography>
+          }
         />
       ))}
     </BoxComponent>

--- a/src/components/atoms/CurrencyOption/index.tsx
+++ b/src/components/atoms/CurrencyOption/index.tsx
@@ -112,7 +112,7 @@ export const CurrencyOptionComponent: React.FC<Props> = props => {
                   </Avatar>
                   <Typography color="textSecondary">{item.id}</Typography>
                 </div>
-                <Typography component="span">{item.freeBalance}</Typography>
+                <Typography component="span">{parseFloat(item.freeBalance.toFixed(4))}</Typography>
               </div>
             </MenuItem>
           ))}


### PR DESCRIPTION
# Title
- [x] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [x] Is your title relatable to the JIRA issue?
- [x] Title <= 100 characters

# Description
- Used `.toFixed` on every balances shown on the apps to 4 decimal places.
- BONUS: converted displayed number with scientific notation (e.g. `1e-8`) into a more common format (`0.00..1`)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Builds and runs on Chrome Desktop
- [x] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Have you added yourself as the Assignee?
- [x] Have you added 1 or more leads as the Reviewer?
- [x] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
