### PR TITLE
Handled showing balance correctly when tipping consecutively

### DIFF
--- a/src/components/Notifications/hooks/use-notification-list.hook.tsx
+++ b/src/components/Notifications/hooks/use-notification-list.hook.tsx
@@ -15,6 +15,7 @@ import {SvgIcon} from '@material-ui/core';
 
 import {useStyles} from '../Notifications.styles';
 
+import {parseScientificNotatedNumber} from 'src/helpers/number';
 import {Notification, NotificationType} from 'src/interfaces/notification';
 import {PostOrigin} from 'src/interfaces/timeline';
 import {PAGINATION_LIMIT} from 'src/lib/api/constants/pagination';
@@ -39,6 +40,26 @@ const getPlatform = (message: string) => {
   const result = message.split(' ');
 
   return result[2];
+};
+
+const parseTipAmountContainingENumber = (message: string) => {
+  const result = message.split(' ');
+
+  let resultInString = '';
+
+  let amount = '';
+
+  if (result.length === 2 && result[0] === '1e-8') {
+    amount = parseScientificNotatedNumber(Number(result[0])) ?? '';
+
+    result[0] = amount;
+
+    resultInString = result.join(' ');
+  } else {
+    resultInString = message;
+  }
+
+  return resultInString;
 };
 
 export const useNotificationList = (
@@ -224,7 +245,9 @@ export const useNotificationList = (
             userId: notification.fromUserId.id,
             user: 'Tips received',
             avatar: notification.fromUserId.profilePictureURL,
-            description: `You received tip from ${notification.fromUserId.name} (${notification.message})}`,
+            description: `You received tip from ${
+              notification.fromUserId.name
+            } (${parseTipAmountContainingENumber(notification.message)})}`,
             badge: (
               <div className={style.circleSuccess}>
                 <SvgIcon
@@ -246,7 +269,9 @@ export const useNotificationList = (
             userId: notification.fromUserId.id,
             user: 'Tips received',
             avatar: notification.fromUserId.profilePictureURL,
-            description: `Your post received tip from ${notification.fromUserId.name} (${notification.message})`,
+            description: `Your post received tip from ${
+              notification.fromUserId.name
+            } (${parseTipAmountContainingENumber(notification.message)})`,
             badge: (
               <div className={style.circleSuccess}>
                 <SvgIcon
@@ -272,7 +297,9 @@ export const useNotificationList = (
             userId: notification.fromUserId.id,
             user: 'Tips received',
             avatar: notification.fromUserId.profilePictureURL,
-            description: `Your reply received tip from ${notification.fromUserId.name} (${notification.message})`,
+            description: `Your reply received tip from ${
+              notification.fromUserId.name
+            } (${parseTipAmountContainingENumber(notification.message)})`,
             badge: (
               <div className={style.circleSuccess}>
                 <SvgIcon

--- a/src/components/WalletBalance/WalletBalance.stories.tsx
+++ b/src/components/WalletBalance/WalletBalance.stories.tsx
@@ -22,6 +22,7 @@ export const WalletBalances = Template.bind({});
 WalletBalances.args = {
   balances: [
     {
+      originBalance: 0,
       freeBalance: 58.4,
       id: CurrencyId.AUSD,
       decimal: 12,
@@ -31,6 +32,7 @@ WalletBalances.args = {
       previousNonce: 0,
     },
     {
+      originBalance: 0,
       freeBalance: 0,
       id: CurrencyId.MYRIA,
       decimal: 18,

--- a/src/interfaces/balance.ts
+++ b/src/interfaces/balance.ts
@@ -2,5 +2,6 @@ import {Currency} from './currency';
 
 export type BalanceDetail = Omit<Currency, 'createdAt' | 'updatedAt'> & {
   freeBalance: number;
+  originBalance: number;
   previousNonce: number;
 };

--- a/src/reducers/balance/actions.ts
+++ b/src/reducers/balance/actions.ts
@@ -88,7 +88,6 @@ export const fetchBalances: ThunkActionCreator<Actions, RootState> =
           if (amount > 0) {
             dispatch(increaseBalance(currency.id, amount));
           } else {
-            console.log({amount});
             dispatch(decreaseBalance(currency.id, Math.abs(amount)));
           }
         });

--- a/src/reducers/balance/actions.ts
+++ b/src/reducers/balance/actions.ts
@@ -88,12 +88,14 @@ export const fetchBalances: ThunkActionCreator<Actions, RootState> =
           if (amount > 0) {
             dispatch(increaseBalance(currency.id, amount));
           } else {
+            console.log({amount});
             dispatch(decreaseBalance(currency.id, Math.abs(amount)));
           }
         });
 
         tokenBalances.push({
           ...currency,
+          originBalance: formatNumber(+free.toString(), currency.decimal),
           freeBalance: formatNumber(+free.toString(), currency.decimal),
           previousNonce: nonce ? +nonce.toString() : 0,
         });

--- a/src/reducers/balance/reducer.ts
+++ b/src/reducers/balance/reducer.ts
@@ -48,7 +48,7 @@ export const BalanceReducer: Redux.Reducer<BalanceState, Actions> = (
         ...state,
         balanceDetails: state.balanceDetails.map(balance => {
           if (balance.id === action.currencyId) {
-            balance.freeBalance += action.change;
+            balance.freeBalance = balance.originBalance + action.change;
           }
 
           return balance;
@@ -61,7 +61,7 @@ export const BalanceReducer: Redux.Reducer<BalanceState, Actions> = (
         ...state,
         balanceDetails: state.balanceDetails.map(balance => {
           if (balance.id === action.currencyId) {
-            balance.freeBalance -= action.change;
+            balance.freeBalance = balance.originBalance - action.change;
           }
 
           return balance;


### PR DESCRIPTION
# Title
- [x] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [x] Is your title relatable to the JIRA issue?
- [x] Title <= 100 characters

# Description
- Added `originBalance` to store the balance at the moment of tipping, then substracting it with `amount`, then assigning it to `freeBalance` to show correctly the balance in UI


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Builds and runs on Chrome Desktop
- [ ] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Have you added yourself as the Assignee?
- [ ] Have you added 1 or more leads as the Reviewer?
- [ ] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
