### PR TITLE
fix experience title format & public key background

### DIFF
--- a/src/components/Expericence/Experience.style.ts
+++ b/src/components/Expericence/Experience.style.ts
@@ -57,7 +57,7 @@ export const useStyles = makeStyles<Theme, ExperienceStyleProps>(theme =>
       },
     },
     title: {
-      wordBreak: 'break-all',
+      wordBreak: 'break-word',
       [theme.breakpoints.down('xs')]: {
         fontSize: '14px',
       },

--- a/src/components/UserSettings/UserSettings.styles.ts
+++ b/src/components/UserSettings/UserSettings.styles.ts
@@ -15,6 +15,8 @@ export const useStyles = makeStyles((theme: Theme) =>
       justifyContent: 'space-between',
     },
     box: {
+      background: theme.palette.background.paper,
+
       [theme.breakpoints.down('xs')]: {
         padding: '0px 20px',
       },


### PR DESCRIPTION
# Fix experience title format & public key background
- [ ] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [ ] Is your title relatable to the JIRA issue?
- [ ] Title <= 100 characters

# Description

Please include a summary of the change in dot point form. Please also include relevant motivation for decisions you made and if there are any TODO items you could not complete. List any dependencies that you added (e.g. package.json).

For example:

- Filename.js: Added comment button to CommentComponent
  - I only enabled the button if the user has logged in (motivation)
  - I couldn't figure out a way to centre the button with flexbox (TODO)
- Filename2.js: bla bla bla
  - nocus dorem iptus locum
- package.json:
  - Added sharp version 2.1.0
    - Need this to compress images (motivation)
    - Tried compress-js but it's deprecated (more motivation)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Builds and runs on Chrome Desktop
- [ ] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Have you added yourself as the Assignee?
- [ ] Have you added 1 or more leads as the Reviewer?
- [ ] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
