### PR TITLE
Added EN-ID translations for Settings interface

### DIFF
--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -46,7 +46,7 @@ const Settings: React.FC = () => {
         <title>{i18n.t('Setting.Title', {appname: publicRuntimeConfig.appName})}</title>
       </Head>
       <TopNavbarComponent
-        description={selected ? `${selected.title}` : 'Set Privacy and Notification settings'}
+        description={selected ? `${selected.title}` : i18n.t('Setting.Default_Title')}
         sectionTitle={SectionTitle.SETTINGS}
         type={selected ? 'back' : 'menu'}
       />

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -46,9 +46,7 @@ const Settings: React.FC = () => {
         <title>{i18n.t('Setting.Title', {appname: publicRuntimeConfig.appName})}</title>
       </Head>
       <TopNavbarComponent
-        description={
-          selected ? `${selected.title} Settings` : 'Set Privacy and Notification settings'
-        }
+        description={selected ? `${selected.title}` : 'Set Privacy and Notification settings'}
         sectionTitle={SectionTitle.SETTINGS}
         type={selected ? 'back' : 'menu'}
       />

--- a/src/components/BlockUserList/BlockList.tsx
+++ b/src/components/BlockUserList/BlockList.tsx
@@ -17,6 +17,7 @@ import useConfirm from 'src/components/common/Confirm/use-confirm.hook';
 import ShowIf from 'src/components/common/show-if.component';
 import {Friend} from 'src/interfaces/friend';
 import {User} from 'src/interfaces/user';
+import i18n from 'src/locale';
 
 type Props = {
   blockList: Friend[];
@@ -45,15 +46,13 @@ export const BlockListComponent: React.FC<Props> = ({blockList, user, onUnblock}
     <>
       <div className={style.root}>
         <Typography className={style.text}>
-          When you blocked someone, that person won&apos;t be able to view your profile and post,
-          add you as a friend, tag you or message you and you won&apos;t see post or notification
-          from them.
+          {i18n.t('Setting.List_Menu.Blocked_Setting.Description')}
         </Typography>
       </div>
 
       <List style={{marginTop: 12}}>
         <ShowIf condition={list.length === 0}>
-          <Empty title="You haven't blocked anyone yet." />
+          <Empty title={i18n.t('Setting.List_Menu.Blocked_Setting.Empty_Block')} />
         </ShowIf>
 
         {list.map(user => (

--- a/src/components/Settings/AccountSettings.tsx
+++ b/src/components/Settings/AccountSettings.tsx
@@ -17,6 +17,7 @@ import {useAccountSetting} from './hooks/use-account-setting.hook';
 import {SettingsOption} from './hooks/use-setting-list.hook';
 
 import {PrivacySettings, PrivacySettingType, PrivacyType} from 'src/interfaces/setting';
+import i18n from 'src/locale';
 
 type AccountSettingsProps = {
   value: PrivacySettings;
@@ -77,7 +78,7 @@ export const AccountSettings: React.FC<AccountSettingsProps> = props => {
           disableElevation
           fullWidth
           onClick={savePrivacySetting}>
-          Save Changes
+          {i18n.t('Setting.List_Menu.Account_Setting.Confirm')}
         </Button>
       </div>
     </Paper>

--- a/src/components/Settings/LanguageSetting.tsx
+++ b/src/components/Settings/LanguageSetting.tsx
@@ -68,7 +68,7 @@ export const LanguageSetting: React.FC<LanguageSettingsProps> = props => {
           disableElevation
           fullWidth
           onClick={saveLanguageSetting}>
-          Save Changes
+          {i18n.t('Setting.List_Menu.Language_Setting.Confirm')}
         </Button>
       </div>
     </Paper>

--- a/src/components/Settings/NotificationSettings.tsx
+++ b/src/components/Settings/NotificationSettings.tsx
@@ -18,6 +18,7 @@ import {
 } from './hooks/use-notification-setting.hook';
 
 import {NotificationSettingItems} from 'src/interfaces/setting';
+import i18n from 'src/locale';
 
 type NotificationSettingsProps = {
   value: NotificationSettingItems;
@@ -74,7 +75,7 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = props =
           disableElevation
           fullWidth
           onClick={saveSetting}>
-          Save Changes
+          {i18n.t('Setting.List_Menu.Notification_Setting.Confirm')}
         </Button>
       </div>
     </Paper>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -11,6 +11,7 @@ import {useStyles} from './Settings.styles';
 import {SettingsOption, useSettingList, SettingsType} from './hooks/use-setting-list.hook';
 
 import {UserSettings} from 'src/interfaces/setting';
+import i18n from 'src/locale';
 
 type SettingsProps = {
   selectedType?: SettingsType;
@@ -38,7 +39,7 @@ export const Settings: React.FC<SettingsProps> = props => {
       {!selected && (
         <>
           <Typography className={styles.title} color="textPrimary">
-            Settings
+            {i18n.t('Setting.Header')}
           </Typography>
           <List>
             {settings
@@ -98,7 +99,7 @@ export const Settings: React.FC<SettingsProps> = props => {
       {selected && (
         <ShowIf condition={selected.id !== 'version' && selected.id !== 'about'}>
           <Typography className={styles.subtitle} color="textPrimary">
-            {selected?.title} Settings
+            {selected?.title}
           </Typography>
           <div>{selected.component}</div>
         </ShowIf>

--- a/src/components/Settings/default.ts
+++ b/src/components/Settings/default.ts
@@ -1,15 +1,16 @@
 import {MenuOptions} from '../atoms/DropdownMenu';
 
 import {LanguageSettingType, PrivacyType} from 'src/interfaces/setting';
+import i18n from 'src/locale';
 
 export const accountPrivacyOptions: MenuOptions<PrivacyType>[] = [
   {
     id: 'private',
-    title: 'Private',
+    title: i18n.t('Setting.List_Menu.Account_Setting.Options.Private'),
   },
   {
     id: 'public',
-    title: 'Public',
+    title: i18n.t('Setting.List_Menu.Account_Setting.Options.Public'),
   },
 ];
 

--- a/src/components/Settings/hooks/use-account-setting.hook.ts
+++ b/src/components/Settings/hooks/use-account-setting.hook.ts
@@ -1,18 +1,19 @@
 import {SettingsOption} from './use-setting-list.hook';
 
 import {PrivacySettingType} from 'src/interfaces/setting';
+import i18n from 'src/locale';
 
 export const useAccountSetting = (): SettingsOption<PrivacySettingType>[] => {
   return [
     {
       id: 'accountPrivacy',
-      title: 'Account privacy',
-      subtitle: 'Change whether people other than friends can see your posts',
+      title: i18n.t('Setting.List_Menu.Account_Setting.Account_Privacy.Title'),
+      subtitle: i18n.t('Setting.List_Menu.Account_Setting.Account_Privacy.Subtitle'),
     },
     {
       id: 'socialMediaPrivacy',
-      title: 'Social media privacy',
-      subtitle: 'Change whether people other than friends can see your social media',
+      title: i18n.t('Setting.List_Menu.Account_Setting.Social_Media_Privacy.Title'),
+      subtitle: i18n.t('Setting.List_Menu.Account_Setting.Social_Media_Privacy.Subtitle'),
     },
   ];
 };

--- a/src/components/Settings/hooks/use-notification-setting.hook.ts
+++ b/src/components/Settings/hooks/use-notification-setting.hook.ts
@@ -3,6 +3,7 @@ import {useState} from 'react';
 import {SettingsOption} from './use-setting-list.hook';
 
 import {NotificationSettingType} from 'src/interfaces/setting';
+import i18n from 'src/locale';
 
 export type NotificationSetting = Record<NotificationSettingType, boolean>;
 export type NotificationSettingsOption = SettingsOption<NotificationSettingType> & {
@@ -15,22 +16,22 @@ export const useNotificationSetting = (setting: NotificationSetting) => {
   const settings: NotificationSettingsOption[] = [
     {
       id: 'comments',
-      title: 'Comments',
+      title: i18n.t('Setting.List_Menu.Notification_Setting.Comments'),
       enabled: notificationSettings.comments,
     },
     {
       id: 'mentions',
-      title: 'Mention',
+      title: i18n.t('Setting.List_Menu.Notification_Setting.Mention'),
       enabled: notificationSettings.mentions,
     },
     {
       id: 'friendRequests',
-      title: 'Friend Request',
+      title: i18n.t('Setting.List_Menu.Notification_Setting.Friend_Requests'),
       enabled: notificationSettings.friendRequests,
     },
     {
       id: 'tips',
-      title: 'Tips',
+      title: i18n.t('Setting.List_Menu.Notification_Setting.Tips'),
       enabled: notificationSettings.tips,
     },
   ];

--- a/src/components/atoms/TopNavbar/TopNavbar.tsx
+++ b/src/components/atoms/TopNavbar/TopNavbar.tsx
@@ -13,6 +13,9 @@ import Typography from '@material-ui/core/Typography';
 import {TopNavbarProps} from './TopNavbar.interfaces';
 import {useStyles} from './TopNavbar.styles';
 
+import {SectionTitle} from 'src/components/atoms/TopNavbar';
+import i18n from 'src/locale';
+
 const MenuDrawerComponent = dynamic(() => import('src/components/Mobile/MenuDrawer/MenuDrawer'), {
   ssr: false,
 });
@@ -60,7 +63,9 @@ export const TopNavbarComponent: React.FC<TopNavbarProps> = props => {
 
       <Grid container direction={reverse ? 'column-reverse' : 'column'}>
         <Typography className={classes.sectionTitle} color="primary">
-          {sectionTitle}
+          {sectionTitle == (SectionTitle.SETTINGS as string)
+            ? i18n.t('Section.Settings')
+            : sectionTitle}
         </Typography>
         <Typography className={classes.description}>{description}</Typography>
       </Grid>

--- a/src/components/common/Help/Help.tsx
+++ b/src/components/common/Help/Help.tsx
@@ -7,6 +7,8 @@ import Typography from '@material-ui/core/Typography';
 
 import {useStyles} from './help.style';
 
+import i18n from 'src/locale';
+
 type HelpComponentProps = {
   support: string;
 };
@@ -33,21 +35,21 @@ export const HelpComponent: React.FC<HelpComponentProps> = props => {
       <ListItem className={style.item} alignItems="center">
         <ListItemText onClick={handleRedirectTermsAndConditions}>
           <Typography className={style.name} component="span" color="textPrimary">
-            Terms and conditions
+            {i18n.t('Setting.List_Menu.Help_Setting.Terms_and_conditions')}
           </Typography>
         </ListItemText>
       </ListItem>
       <ListItem className={style.item} alignItems="center">
         <ListItemText onClick={handleRedirectPrivacyAndPolicy}>
           <Typography className={style.name} component="span" color="textPrimary">
-            Privacy and Policy
+            {i18n.t('Setting.List_Menu.Help_Setting.Privacy_and_policy')}
           </Typography>
         </ListItemText>
       </ListItem>
       <ListItem className={style.item} alignItems="center">
         <ListItemText onClick={handleRedirectToTelegram}>
           <Typography className={style.name} component="span" color="textPrimary">
-            Contact us
+            {i18n.t('Setting.List_Menu.Help_Setting.Contact_us')}
           </Typography>
         </ListItemText>
       </ListItem>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -247,6 +247,7 @@
   },
   "Setting": {
     "Title": "{{appname}} - Settings",
+    "Header": "Setting",
     "List_Menu": {
       "Account_Title": "Privacy Settings",
       "Account_Subtitle": "Account privacy, social media privacy",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -288,6 +288,11 @@
       },
       "Help_Title": "Help",
       "Help_Subtitle": "Terms and conditions, privacy policy, contact us",
+      "Help_Setting": {
+        "Terms_and_conditions": "Terms and conditions",
+        "Privacy_and_policy": "Privacy and Policy",
+        "Contact_us": "Contact us"
+      },
       "About_Title": "About Myriad",
       "About_Subtitle": "Read more about Myriad",
       "Feedback_Title": "Submit Feedback",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -277,6 +277,10 @@
       },
       "Blocked_Title": "Blocked User Settings",
       "Blocked_Subtitle": "Manage your blocked list",
+      "Blocked_Setting": {
+        "Description": "When you blocked someone, that person won't be able to view your profile and post, add you as a friend, tag you or message you and you won't see post or notification from them.",
+        "Empty_Block": "You haven't blocked anyone yet"
+      },
       "Language_Title": "Language Settings",
       "Language_Subtitle": "Change the language used in the user interface",
       "Help_Title": "Help",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -248,13 +248,28 @@
   "Setting": {
     "Title": "{{appname}} - Settings",
     "List_Menu": {
-      "Account_Title": "Privacy",
+      "Account_Title": "Privacy Settings",
       "Account_Subtitle": "Account privacy, social media privacy",
-      "Notification_Title": "Notification",
+      "Account_Setting": {
+        "Account_Privacy": {
+        "Title": "Account privacy",
+        "Subtitle": "Change whether people other than friends can see your posts"
+        },
+        "Social_Media_Privacy": {
+      "Title": "Social media privacy",
+      "Subtitle": "Change whether people other than friends can see your social media"
+        },
+        "Options": {
+          "Private": "Private",
+          "Public": "Public"
+        },
+        "Confirm": "Save changes"
+      },
+      "Notification_Title": "Notification Settings",
       "Notification_Subtitle": "Manage your notification",
-      "Blocked_Title": "Blocked User",
+      "Blocked_Title": "Blocked User Settings",
       "Blocked_Subtitle": "Manage your blocked list",
-      "Language_Title": "Language",
+      "Language_Title": "Language Settings",
       "Language_Subtitle": "Change the language used in the user interface",
       "Help_Title": "Help",
       "Help_Subtitle": "Terms and conditions, privacy policy, contact us",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -253,12 +253,12 @@
       "Account_Subtitle": "Account privacy, social media privacy",
       "Account_Setting": {
         "Account_Privacy": {
-        "Title": "Account privacy",
-        "Subtitle": "Change whether people other than friends can see your posts"
+          "Title": "Account privacy",
+          "Subtitle": "Change whether people other than friends can see your posts"
         },
         "Social_Media_Privacy": {
-      "Title": "Social media privacy",
-      "Subtitle": "Change whether people other than friends can see your social media"
+          "Title": "Social media privacy",
+          "Subtitle": "Change whether people other than friends can see your social media"
         },
         "Options": {
           "Private": "Private",
@@ -268,6 +268,13 @@
       },
       "Notification_Title": "Notification Settings",
       "Notification_Subtitle": "Manage your notification",
+      "Notification_Setting": {
+        "Comments": "Comments",
+        "Mention": "Mention",
+        "Friend_Requests": "Friend Request",
+        "Tips": "Tips",
+        "Confirm": "Save changes"
+      },
       "Blocked_Title": "Blocked User Settings",
       "Blocked_Subtitle": "Manage your blocked list",
       "Language_Title": "Language Settings",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -283,6 +283,9 @@
       },
       "Language_Title": "Language Settings",
       "Language_Subtitle": "Change the language used in the user interface",
+      "Language_Setting": {
+        "Confirm": "Save changes"
+      },
       "Help_Title": "Help",
       "Help_Subtitle": "Terms and conditions, privacy policy, contact us",
       "About_Title": "About Myriad",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -245,8 +245,22 @@
   "Search": {
     "Title": "{{appname}} - Search Result"
   },
+  "Section": {
+    "Friends": "Friends",
+    "Social_Media": "Social Media",
+    "Wallet": "Wallet",
+    "Experience": "Experience",
+    "Profile": "Profile",
+    "Settings": "Settings",
+    "Notification": "Notification",
+    "Timeline": "Timeline",
+    "NFT": "NFT",
+    "Social_Token": "Social Token",
+    "Trends": "Trends"
+  },
   "Setting": {
     "Title": "{{appname}} - Settings",
+    "Default_Title": "Set Privacy and Notification settings",
     "Header": "Setting",
     "List_Menu": {
       "Account_Title": "Privacy Settings",

--- a/src/locale/id.json
+++ b/src/locale/id.json
@@ -241,8 +241,22 @@
   "Search": {
     "Title": "{{appname}} - Hasil Pencarian"
   },
+  "Section": {
+    "Friends": "Teman",
+    "Social_Media": "Media Sosial",
+    "Wallet": "Dompet",
+    "Experience": "Pengalaman",
+    "Profile": "Profil",
+    "Settings": "Pengaturan",
+    "Notification": "Notifikasi",
+    "Timeline": "Linimasa",
+    "NFT": "NFT",
+    "Social_Token": "Token sosial",
+    "Trends": "Tren"
+  },
   "Setting": {
     "Title": "{{appname}} - Pengaturan",
+    "Default_Title": "Tentukan pengaturan privasi dan notifikasi",
     "Header": "Pengaturan",
     "List_Menu": {
       "Account_Title": "Pengaturan Akun",

--- a/src/locale/id.json
+++ b/src/locale/id.json
@@ -243,6 +243,7 @@
   },
   "Setting": {
     "Title": "{{appname}} - Pengaturan",
+    "Header": "Pengaturan",
     "List_Menu": {
       "Account_Title": "Pengaturan Akun",
       "Account_Subtitle": "Privasi akun, privasi sosial media",

--- a/src/locale/id.json
+++ b/src/locale/id.json
@@ -274,6 +274,10 @@
       },
       "Blocked_Title": "Pengguna Diblokir",
       "Blocked_Subtitle": "Pengaturan daftar pengguna yang diblokir",
+      "Blocked_Setting": {
+        "Description": "Ketika Anda memblokir pengguna lain, pengguna tersebut tidak akan dapat melihat profil dan konten Anda, menambahkan Anda sebagai teman, menyebutkan Anda atau mengirimkan Anda pesan dan Anda tidak akan melihat konten dan notifikasi dari mereka",
+        "Empty_Block": "Anda belum memblokir siapapun"
+      },
       "Language_Title": "Pengaturan Bahasa",
       "Language_Subtitle": "Ubah bahasa yang digunakan pada layanan antar muka",
       "Help_Title": "Bantuan",

--- a/src/locale/id.json
+++ b/src/locale/id.json
@@ -285,6 +285,11 @@
       },
       "Help_Title": "Bantuan",
       "Help_Subtitle": "Syarat dan ketentuan, kebijakan privasi, hubungi kami",
+      "Help_Setting": {
+        "Terms_and_conditions": "Syarat dan ketentuan",
+        "Privacy_and_policy": "Kebijakan privasi",
+        "Contact_us": "Hubungi kami"
+      },
       "About_Title": "Tentang Myriad",
       "About_Subtitle": "Ketahui lebih banyak tentang Myriad",
       "Feedback_Title": "Berikan Tanggapan",

--- a/src/locale/id.json
+++ b/src/locale/id.json
@@ -265,6 +265,13 @@
       },
       "Notification_Title": "Notifikasi",
       "Notification_Subtitle": "Pengaturan notifikasi",
+      "Notification_Setting": {
+        "Comments": "Komentar",
+        "Mention": "Sebutan",
+        "Friend_Requests": "Ajakan Berteman",
+        "Tips": "Tip",
+        "Confirm": "Simpan perubahan"
+      },
       "Blocked_Title": "Pengguna Diblokir",
       "Blocked_Subtitle": "Pengaturan daftar pengguna yang diblokir",
       "Language_Title": "Pengaturan Bahasa",

--- a/src/locale/id.json
+++ b/src/locale/id.json
@@ -244,13 +244,29 @@
   "Setting": {
     "Title": "{{appname}} - Pengaturan",
     "List_Menu": {
-      "Account_Title": "Akun",
+      "Account_Title": "Pengaturan Akun",
       "Account_Subtitle": "Privasi akun, privasi sosial media",
+      "Account_Setting": {
+        "Account_Privacy": {
+          "Title": "Privasi akun",
+          "Subtitle": 
+          "Pengaturan visibilitas akun Anda terhadap pengguna selain teman"
+        },
+        "Social_Media_Privacy": {
+          "Title": "Privasi media sosial",
+          "Subtitle": "Pengaturan visibilitas media sosial Anda terhadap pengguna selain teman"
+        },
+        "Options": {
+          "Private": "Privat",
+          "Public": "Publik"
+        },
+        "Confirm": "Simpan perubahan"
+      },
       "Notification_Title": "Notifikasi",
       "Notification_Subtitle": "Pengaturan notifikasi",
       "Blocked_Title": "Pengguna Diblokir",
       "Blocked_Subtitle": "Pengaturan daftar pengguna yang diblokir",
-      "Language_Title": "Bahasa",
+      "Language_Title": "Pengaturan Bahasa",
       "Language_Subtitle": "Ubah bahasa yang digunakan pada layanan antar muka",
       "Help_Title": "Bantuan",
       "Help_Subtitle": "Syarat dan ketentuan, kebijakan privasi, hubungi kami",
@@ -258,7 +274,7 @@
       "About_Subtitle": "Ketahui lebih banyak tentang Myriad",
       "Feedback_Title": "Berikan Tanggapan",
       "Feedback_Subtitle": "Silahkan berikan pengalaman kamu melalui email",
-      "Version_Title": "Myriad versi"
+      "Version_Title": "Versi Myriad"
     }
   },
   "SocialMedia": {

--- a/src/locale/id.json
+++ b/src/locale/id.json
@@ -280,6 +280,9 @@
       },
       "Language_Title": "Pengaturan Bahasa",
       "Language_Subtitle": "Ubah bahasa yang digunakan pada layanan antar muka",
+      "Language_Setting": {
+        "Confirm": "Simpan perubahan"
+      },
       "Help_Title": "Bantuan",
       "Help_Subtitle": "Syarat dan ketentuan, kebijakan privasi, hubungi kami",
       "About_Title": "Tentang Myriad",


### PR DESCRIPTION
# Title
- [x] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [x] Is your title relatable to the JIRA issue?
- [x] Title <= 100 characters

# Description
- Added text in `src/locale` for `en` and `id` translations for the Settings page.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Builds and runs on Chrome Desktop
- [x] Builds and runs on Chrome Responsive
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Have you added yourself as the Assignee?
- [x] Have you added 1 or more leads as the Reviewer?
- [x] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
