### PR TITLE
fix: removed data when PATCH notifications

### DIFF
--- a/src/lib/api/notification.ts
+++ b/src/lib/api/notification.ts
@@ -45,10 +45,9 @@ export const markAsRead = async (id: string): Promise<void> => {
   });
 };
 
-export const markItemsAsRead = async (ids: string[]): Promise<void> => {
+export const markItemsAsRead = async (): Promise<void> => {
   await MyriadAPI().request<TotalNewNotification>({
     url: `/notifications/read`,
     method: 'PATCH',
-    data: ids,
   });
 };

--- a/src/reducers/notification/actions.ts
+++ b/src/reducers/notification/actions.ts
@@ -118,14 +118,13 @@ export const readAllNotifications: ThunkActionCreator<Actions, RootState> =
     try {
       const {
         userState: {user},
-        notificationState: {notifications},
       } = getState();
 
       if (!user) {
         throw new Error('User not found');
       }
 
-      await NotificationAPI.markItemsAsRead(notifications.map(notification => notification.id));
+      await NotificationAPI.markItemsAsRead();
 
       dispatch({
         type: constants.MARK_ALL_READ,


### PR DESCRIPTION
## Describe your changes
- Relate to MYR-2314
- Removed data when PATCH notifications (mark read all notifications)

## Issue ticket number / link
[MYR-2343: Notification doesn't Clear up when mark as read is clicked](https://blocksphere2020.atlassian.net/browse/MYR-2343)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
