### PR TITLE
fix: remove send tip button when imported post has owner

### DIFF
--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -44,7 +44,7 @@ export const PostDetail: React.FC<PostDetailProps> = props => {
   const isPostCreator = post.createdBy === user?.id;
   const isInternalPost = post.platform === 'myriad';
   const isExternalPost = post.platform !== 'myriad';
-  const isOriginOwner = user?.people?.find(person => person.id === post.peopleId) ? true : false;
+  const isOriginOwner = post?.people?.userSocialMedia?.userId === user?.id;
   const showTipButton = (isInternalPost && !isPostCreator) || (isExternalPost && !isOriginOwner);
   const isPostOwner = isInternalPost ? isPostCreator : isOriginOwner;
 

--- a/src/interfaces/people.ts
+++ b/src/interfaces/people.ts
@@ -22,3 +22,7 @@ export interface People extends PeopleProps {
   hide?: boolean;
   walletDetail?: WalletDetail;
 }
+
+export interface PeopleWithSocialMedaia extends People {
+  userSocialMedia?: UserSocialMedia;
+}

--- a/src/interfaces/post.ts
+++ b/src/interfaces/post.ts
@@ -1,7 +1,7 @@
 import {BaseModel} from './base.interface';
 import {Comment} from './comment';
 import {Vote} from './interaction';
-import {People} from './people';
+import {PeopleWithSocialMedaia} from './people';
 import {PostOrigin} from './timeline';
 import {User} from './user';
 
@@ -102,9 +102,10 @@ export type PostEmbedProps = {
   image?: EmbedMediaProps;
   video?: EmbedMediaProps;
 };
+
 export interface Post extends PostProps, PostCustomProps, BaseModel {
   user: User;
-  people?: People;
+  people?: PeopleWithSocialMedaia;
   comments?: Comment[];
   //TODO: change this on migrating new schema of transaction
   transactions?: any[];


### PR DESCRIPTION
## Describe your changes
- Remove send tip button when imported post has owner

## Issue ticket number / link
[MYR-2300: Send tip button on my claimed socmed post still active](https://blocksphere2020.atlassian.net/browse/MYR-2300)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
