### PR TITLE
fix: enable web2 user to create exclusive content

### DIFF
--- a/src/components/PostCreate/PostCreate.tsx
+++ b/src/components/PostCreate/PostCreate.tsx
@@ -5,7 +5,7 @@ import {useDispatch} from 'react-redux';
 
 import dynamic from 'next/dynamic';
 
-import {Button, IconButton, SvgIcon, Tooltip, Typography} from '@material-ui/core';
+import {Button, IconButton, SvgIcon, Typography} from '@material-ui/core';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 
@@ -350,7 +350,7 @@ export const PostCreate: React.FC<PostCreateProps> = props => {
           <ShowIf condition={!showExclusive}>
             {!exclusiveContent ? (
               <>
-                {user.fullAccess ? (
+                {(
                   <IconButton aria-label="exclusive-content" onClick={handleshowExclusive}>
                     <SvgIcon component={GiftIcon} viewBox="0 0 24 24" className={styles.giftIcon} />
                     <Typography
@@ -361,25 +361,6 @@ export const PostCreate: React.FC<PostCreateProps> = props => {
                       {i18n.t('ExclusiveContent.Add')}
                     </Typography>
                   </IconButton>
-                ) : (
-                  <Tooltip
-                    title={<Typography>{i18n.t('ExclusiveContent.Text.Tooltip')}</Typography>}
-                    aria-label="exclusive-content">
-                    <IconButton aria-label="exclusive-content" onClick={null}>
-                      <SvgIcon
-                        component={GiftIcon}
-                        viewBox="0 0 24 24"
-                        className={styles.giftIconGray}
-                      />
-                      <Typography
-                        component="span"
-                        color={'#C2C2C2' as never}
-                        variant="body1"
-                        style={{lineHeight: 1.8}}>
-                        {i18n.t('ExclusiveContent.Add')}
-                      </Typography>
-                    </IconButton>
-                  </Tooltip>
                 )}
               </>
             ) : (

--- a/src/components/PostCreate/PostCreate.tsx
+++ b/src/components/PostCreate/PostCreate.tsx
@@ -350,18 +350,16 @@ export const PostCreate: React.FC<PostCreateProps> = props => {
           <ShowIf condition={!showExclusive}>
             {!exclusiveContent ? (
               <>
-                {(
-                  <IconButton aria-label="exclusive-content" onClick={handleshowExclusive}>
-                    <SvgIcon component={GiftIcon} viewBox="0 0 24 24" className={styles.giftIcon} />
-                    <Typography
-                      component="span"
-                      color="primary"
-                      variant="body1"
-                      style={{lineHeight: 1.8}}>
-                      {i18n.t('ExclusiveContent.Add')}
-                    </Typography>
-                  </IconButton>
-                )}
+                <IconButton aria-label="exclusive-content" onClick={handleshowExclusive}>
+                  <SvgIcon component={GiftIcon} viewBox="0 0 24 24" className={styles.giftIcon} />
+                  <Typography
+                    component="span"
+                    color="primary"
+                    variant="body1"
+                    style={{lineHeight: 1.8}}>
+                    {i18n.t('ExclusiveContent.Add')}
+                  </Typography>
+                </IconButton>
               </>
             ) : (
               <>


### PR DESCRIPTION
## Describe your changes
- remove tooltip and enable web2 user to create exclusive content by remove condition in PostCreate component

## Issue ticket number / link
- https://blocksphere2020.atlassian.net/browse/MYR-2914

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
