### PR TITLE
fix: Disable Image Paste on Post Create

### DIFF
--- a/src/components/PostCreate/PostCreate.tsx
+++ b/src/components/PostCreate/PostCreate.tsx
@@ -136,6 +136,12 @@ export const PostCreate: React.FC<PostCreateProps> = props => {
     setPost(prevPost => ({ ...prevPost, visibility }));
   };
 
+  const handleImagePaste = event => {
+    if (event.clipboardData.getData('image') != '') {
+      event.preventDefault();
+    }
+  };
+
   const handleSubmit = () => {
     if (activeTab === 'import' && importUrl) {
       onSubmit(importUrl, {
@@ -427,6 +433,7 @@ export const PostCreate: React.FC<PostCreateProps> = props => {
       title={handleTitleModal().title}
       subtitle={handleTitleModal().subtitle}
       onClose={handleClose}
+      onPaste={handleImagePaste}
       open={open}
       fullScreen={isMobile}
       maxWidth="md"


### PR DESCRIPTION
## Describe your changes
I add onPaste event handler to disable paste if the clipboard data is image type. I am still not sure if the handler is correct and if the position of the onPaste event is correct
## Issue ticket number / link
MYR-3036
https://blocksphere2020.atlassian.net/jira/software/c/projects/MYR/boards/12/backlog?view=detail&selectedIssue=MYR-3036&issueLimit=100