### PR TITLE
fix: disable create post button when editor is empty or timeline not selected

### DIFF
--- a/src/components/PostCreate/PostCreate.tsx
+++ b/src/components/PostCreate/PostCreate.tsx
@@ -617,7 +617,7 @@ export const PostCreate: React.FC<PostCreateProps> = props => {
         <ShowIf condition={!showExclusive}>
           <ShowIf condition={post.visibility !== 'selected_user'}>
             <Button
-              disabled={editorValue === ''}
+              disabled={editorValue === '' || timelineId.length === 0}
               variant="contained"
               color="primary"
               size="small"


### PR DESCRIPTION
## Describe your changes
Disable create post button when editor is empty or when timeline not yet chosen
## Issue ticket number / link
MYR-3080